### PR TITLE
feat: 基本的な数学演算ユーティリティクラスの追加

### DIFF
--- a/lib/math_utils.rb
+++ b/lib/math_utils.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MathUtils
+  def self.square(number)
+    number * number
+  end
+
+  def self.square_root(number)
+    raise ArgumentError, '負の数の平方根は計算できません' if number.negative?
+
+    Math.sqrt(number)
+  end
+
+  def self.factorial(number)
+    raise ArgumentError, '負の数の階乗は計算できません' if number.negative?
+    return 1 if number.zero?
+
+    (1..number).reduce(:*)
+  end
+end

--- a/lib/math_utils_test.rb
+++ b/lib/math_utils_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'math_utils'
+
+class MathUtilsTest < Minitest::Test
+  def test_square
+    assert_equal 25, MathUtils.square(5)
+    assert_equal 0, MathUtils.square(0)
+    assert_equal 16, MathUtils.square(-4)
+  end
+
+  def test_square_root
+    assert_equal 3.0, MathUtils.square_root(9)
+    assert_equal 0.0, MathUtils.square_root(0)
+    assert_raises(ArgumentError) { MathUtils.square_root(-1) }
+  end
+
+  def test_factorial
+    assert_equal 1, MathUtils.factorial(0)
+    assert_equal 1, MathUtils.factorial(1)
+    assert_equal 120, MathUtils.factorial(5)
+    assert_raises(ArgumentError) { MathUtils.factorial(-1) }
+  end
+end


### PR DESCRIPTION
## 概要
基本的な数学演算を行うユーティリティクラスを追加

### 関連 Issue / ドキュメント
※ サンプルPR作成のため、関連Issueはありません

### 変更内容
- 基本的な数学演算を行う`MathUtils`クラスを実装
  - `square`: 数値の二乗を計算
  - `square_root`: 数値の平方根を計算（負の数の場合はエラー）
  - `factorial`: 数値の階乗を計算（負の数の場合はエラー）
- 各メソッドのテストケースを追加
  - 正常系・異常系のテストを実装
  - エラーケースの検証も含む

## レビュアーに特に見て欲しいところ
- エラーハンドリングの実装が適切か
- テストケースの網羅性

## 動作確認手順
1. テストの実行
```bash
ruby lib/math_utils_test.rb
```